### PR TITLE
Allow environment variables in schema definition

### DIFF
--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -114,6 +114,32 @@ This is useful if you need to anonymize one or more specific records, eg for "Ri
             provider:
               name: clear
 
+YAML schema file supports placeholders with environment variables, ex:
+
+`!ENV ${HOST}``
+
+`!ENV '/var/${LOG_PATH}'`
+
+So you can construct dynamic filter conditions like:
+.. code-block:: sh
+    $ export COMPANY_ID=123
+
+    $ export ACTION_TO_BE_TAKEN=clear
+
+    $ pganonymize
+
+
+***Example**::
+
+    - login:
+        search: id = '!ENV ${COMPANY_ID}'
+        search2: id = ${COMPANY_ID}
+        search3: username = '${USER_TO_BE_SEARCHED}'
+        fields:
+         - first_name:
+            provider:
+              name: ${ACTION_TO_BE_TAKEN}
+
 ``chunk_size``
 ~~~~~~~~~~~~~~
 

--- a/pganonymizer/cli.py
+++ b/pganonymizer/cli.py
@@ -6,11 +6,9 @@ import argparse
 import logging
 import time
 
-import yaml
-
 from pganonymizer.constants import DATABASE_ARGS, DEFAULT_SCHEMA_FILE
 from pganonymizer.providers import provider_registry
-from pganonymizer.utils import anonymize_tables, create_database_dump, get_connection, truncate_tables
+from pganonymizer.utils import anonymize_tables, create_database_dump, get_connection, load_config, truncate_tables
 
 
 def get_pg_args(args):
@@ -64,7 +62,7 @@ def main(args):
         list_provider_classes()
         return 0
 
-    schema = yaml.load(open(args.schema), Loader=yaml.FullLoader)
+    schema = load_config(args.schema)
 
     pg_args = get_pg_args(args)
     connection = get_connection(pg_args)

--- a/pganonymizer/utils.py
+++ b/pganonymizer/utils.py
@@ -85,7 +85,7 @@ def build_and_then_import_data(connection, table, primary_key, columns,
     if dry_run:
         sql_select = Composed([sql_select, SQL(" LIMIT 100")])
         logging.info(sql_select.as_string(connection))
-    cursor = connection.cursor(cursor_factory=psycopg2.extras.DictCursor, name='fetch_large_result')    
+    cursor = connection.cursor(cursor_factory=psycopg2.extras.DictCursor, name='fetch_large_result')
     cursor.execute(sql_select.as_string(connection))
     temp_table = 'tmp_{table}'.format(table=table)
     create_temporary_table(connection, columns, table, temp_table, primary_key)

--- a/tests/schemes/schema_with_env_variables.yml
+++ b/tests/schemes/schema_with_env_variables.yml
@@ -1,0 +1,13 @@
+primary_key: !ENV ${TEST_PRIMARY_KEY}
+primary_key2: !ENV ${TEST_PRIMARY_KEY}
+chunk_size: !ENV ${TEST_CHUNK_SIZE}
+concat_missing: !ENV 'Hello, ${MISSING_ENV_VAL}'
+concat_missing2: 'Hello, ${MISSING_ENV_VAL}'
+concat_present: !ENV 'Hello, ${PRESENT_WORLD_NAME}'
+concat_present2: ${PRESENT_WORLD_NAME}
+concat_present3: Hello, ${PRESENT_WORLD_NAME}
+search: id = ${COMPANY_ID}
+search2: username = '${USER_TO_BE_SEARCHED}'
+corrupted: username = '${CORRUPTED
+corrupted2: !ENV
+corrupted3: !ENV $


### PR DESCRIPTION
Hi! This PR introduces environment variable substitution for schema configuration

Now you can craft config file like this:

```
    tables:
     - auth_user:
        search: id  = '${USER_ID_TO_BE_DELETED}'
        fields:
         - first_name:
            provider:
              name: clear
```

and then run 
`USER_ID_TO_BE_DELETED=145 anonymizer`