### PR TITLE
Pass kwargs through to faker functions from schema

### DIFF
--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -272,6 +272,9 @@ The ``clear`` provider will set a database field to ``null``.
 * ``fake.first_name``
 * ``fake.street_name``
 
+Some fake functions allow additional parameters to be passed, these can be specified in
+the schema as ``kwargs``.
+
 .. note::
    Please note: using the ``Faker`` library will generate randomly generated data for each data row
    within a table. This will dramatically slow down the anonymization process.
@@ -286,8 +289,14 @@ The ``clear`` provider will set a database field to ``null``.
          - email:
             provider:
               name: fake.email
+         - birth_date:
+            provider:
+              name: fake.date_of_birth
+              kwargs:
+                minimum_age: 18
 
 See the `Faker documentation`_ for a full set of providers.
+
 
 ``mask``
 ~~~~~~~~

--- a/pganonymize/providers.py
+++ b/pganonymize/providers.py
@@ -114,11 +114,12 @@ class FakeProvider(Provider):
 
     def alter_value(self, value):
         func_name = self.kwargs['name'].split('.', 1)[1]
+        func_kwargs = self.kwargs.get('kwargs', {})
         try:
             func = operator.attrgetter(func_name)(fake_data)
         except AttributeError as exc:
             raise InvalidProviderArgument(exc)
-        return func()
+        return func(**func_kwargs)
 
 
 @register('mask')

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 import pytest
 import six
-from mock import MagicMock, Mock, patch
+from mock import MagicMock, Mock, patch, call
 
 from pganonymize import exceptions, providers
 
@@ -134,6 +134,17 @@ class TestFakeProvider:
         provider = providers.FakeProvider(name=name)
         with pytest.raises(exceptions.InvalidProviderArgument):
             provider.alter_value('Foo')
+
+
+    @patch('pganonymize.providers.fake_data')
+    def test_alter_value_with_kwargs(self, mock_fake_data):
+        provider = providers.FakeProvider(
+            name='fake.date_of_birth', kwargs={
+                "minimum_age": 18
+            }
+        )
+        provider.alter_value("Foo")
+        assert mock_fake_data.date_of_birth.call_args == call(minimum_age=18)
 
 
 class TestMaskProvider:


### PR DESCRIPTION
This change would allow us to pass kwargs through to faker functions. Some [fake functions](https://faker.readthedocs.io/en/master/providers/faker.providers.date_time.html#faker.providers.date_time.Provider.date_of_birth) allow parameters, this ensures that they can be used.