### PR TITLE
Add partial masked provider

### DIFF
--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -311,6 +311,30 @@ This provider will replace each character with a static sign.
               sign: '?'
 
 
+``partial_mask``
+~~~~~~~~
+
+**Arguments:**
+
+* ``sign``: The sign to be used to replace the original characters (default ``X``).
+* ``unmasked_left``: The number of characters on the left side to leave unmasked (default 1).
+* ``unmasked_right``: The number of characters on the right side to leave unmasked (default 1).
+
+This provider will replace some characters with a static sign. It will leave some characters on the left and right unmasked, you can determine how many by providing ``unmasked_left`` and ``unmasked_right`` arguments.
+
+**Example usage**:
+
+.. code-block:: yaml
+
+    tables:
+     - auth_user:
+        fields:
+         - last_name:
+            provider:
+              name: mask
+              sign: '?'
+
+
 ``md5``
 ~~~~~~~
 

--- a/pganonymize/providers.py
+++ b/pganonymize/providers.py
@@ -133,6 +133,27 @@ class MaskProvider(Provider):
         return sign * len(value)
 
 
+@register('partial_mask')
+class PartialMaskProvider(Provider):
+    """Provider that masks some of the original value."""
+
+    default_sign = 'X'
+    default_unmasked_left = 1
+    default_unmasked_right = 1
+    """The default string used to replace each character."""
+
+    def alter_value(self, value):
+        sign = self.kwargs.get('sign', self.default_sign) or self.default_sign
+        unmasked_left = self.kwargs.get('unmasked_left', self.default_unmasked_left) or self.default_unmasked_left
+        unmasked_right = self.kwargs.get('unmasked_right', self.default_unmasked_right) or self.default_unmasked_right
+
+        return (
+            value[:unmasked_left] +
+            (len(value) - (unmasked_left + unmasked_right)) * sign +
+            value[-unmasked_right:]
+        )
+
+
 @register('md5')
 class MD5Provider(Provider):
     """Provider to hash a value with the md5 algorithm."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -147,6 +147,22 @@ class TestMaskProvider:
         assert provider.alter_value(value) == expected
 
 
+class TestPartialMaskProvider:
+
+    @pytest.mark.parametrize('value, sign, unmasked_left, unmasked_right, expected', [
+        ('Foo', None, 1, 1, 'FXo'),
+        ('Foo', None, 0, 0, 'FXo'),
+        ('Baaaar', '?', 2, 1, 'Ba???r'),
+    ])
+    def test_alter_value(self, value, sign, unmasked_left, unmasked_right, expected):
+        provider = providers.PartialMaskProvider(
+            sign=sign,
+            unmasked_left=unmasked_left,
+            unmasked_right=unmasked_right
+        )
+        assert provider.alter_value(value) == expected
+
+
 class TestMD5Provider:
 
     def test_alter_value(self):


### PR DESCRIPTION
Adds a new provider which applies partial masking. The provider can be configured to leave an amount of characters on both the left and right side of a string unmasked.