### PR TITLE
#56: Add Trusted Publisher Management workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,22 +6,24 @@ on:
 
 jobs:
   publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
-    environment: production
+    environment:
+      name: production
+      url: https://pypi.org/project/pganonymize/
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+      - name: Build and publish
+        run: python setup.py sdist bdist_wheel
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel
-      - name: Build and publish
+      - name: Build
         run: python setup.py sdist bdist_wheel
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,42 +3,40 @@ name: Test
 on: [push]
 
 jobs:
-  linting:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
-    - name: Lint
-      run: tox -e flake8
   tests:
-    needs: linting
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
-    env:
-      PYTHON: ${{ matrix.python-version }}
+        image:
+          - 'python:2.7-buster'
+          - 'python:3.6-bullseye'
+          - 'python:3.7-bookworm'
+          - 'python:3.8-bookworm'
+          - 'python:3.9-bookworm'
+          - 'python:3.10-bookworm'
+          - 'python:3.11-bookworm'
+          - 'python:3.12-bookworm'
+    container:
+      image: ${{ matrix.image }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      id: setup-python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Set environment variables
       run: |
-        python -m pip install --upgrade pip
-        pip install --use-pep517 tox "coverage<5"
-    - name: Run tests
-      run: |
-        export TOXENV=$(echo "py${{ matrix.python-version }}" | sed 's/\.//g')
-        tox -- -p no:warnings
+        echo "PYTHON=$(echo '${{ matrix.image }}' | sed -r 's/^python:([0-9]+)\.([0-9]+).*$/\1.\2/g')" >> $GITHUB_ENV
+        echo "TOXFACTOR=$(echo '${{ matrix.image }}' | sed -r 's/^python:([0-9]+)\.([0-9]+).*$/py\1\2/g')" >> $GITHUB_ENV
+    - name: Install importlib-metadata for older Python versions
+      run: pip install "importlib-metadata<3"
+      if: >-
+        matrix.image == 'python:2.7-buster' ||
+        matrix.image == 'python:3.6-bullseye' ||
+        matrix.image == 'python:3.7-bookworm'
+    - name: Install test utilities
+      run: pip install "tox<4" tox-factor "coverage<5"
+    - name: Lint with flake8
+      run: tox -e flake8
+      if: matrix.image == 'python:3.12-bookworm'
+    - name: Test via tox
+      run: tox -- -p no:warnings
     - name: Generate coverage report
       run: coverage html
       if: ${{ success() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -25,10 +25,10 @@ jobs:
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       id: setup-python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,40 +3,42 @@ name: Test
 on: [push]
 
 jobs:
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Lint
+      run: tox -e flake8
   tests:
+    needs: linting
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image:
-          - 'python:2.7-buster'
-          - 'python:3.6-bullseye'
-          - 'python:3.7-bookworm'
-          - 'python:3.8-bookworm'
-          - 'python:3.9-bookworm'
-          - 'python:3.10-bookworm'
-          - 'python:3.11-bookworm'
-          - 'python:3.12-bookworm'
-    container:
-      image: ${{ matrix.image }}
+        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
+    env:
+      PYTHON: ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v3
-    - name: Set environment variables
+    - name: Set up Python ${{ matrix.python-version }}
+      id: setup-python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
       run: |
-        echo "PYTHON=$(echo '${{ matrix.image }}' | sed -r 's/^python:([0-9]+)\.([0-9]+).*$/\1.\2/g')" >> $GITHUB_ENV
-        echo "TOXFACTOR=$(echo '${{ matrix.image }}' | sed -r 's/^python:([0-9]+)\.([0-9]+).*$/py\1\2/g')" >> $GITHUB_ENV
-    - name: Install importlib-metadata for older Python versions
-      run: pip install "importlib-metadata<3"
-      if: >-
-        matrix.image == 'python:2.7-buster' ||
-        matrix.image == 'python:3.6-bullseye' ||
-        matrix.image == 'python:3.7-bookworm'
-    - name: Install test utilities
-      run: pip install "tox<4" tox-factor "coverage<5"
-    - name: Lint with flake8
-      run: tox -e flake8
-      if: matrix.image == 'python:3.12-bookworm'
-    - name: Test via tox
-      run: tox -- -p no:warnings
+        python -m pip install --upgrade pip
+        pip install --use-pep517 tox "coverage<5"
+    - name: Run tests
+      run: |
+        export TOXENV=$(echo "py${{ matrix.python-version }}" | sed 's/\.//g')
+        tox -- -p no:warnings
     - name: Generate coverage report
       run: coverage html
       if: ${{ success() }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 -----------
 
+* `#56 <https://github.com/rheinwerk-verlag/pganonymize/issues/56>`_: Add Trusted Publisher Management workflow
+
 0.11.0 (2024-02-29)
 -------------------
 


### PR DESCRIPTION
This PR changes the "publish" workflow to work with the Trusted Publisher Management, see

- https://docs.pypi.org/trusted-publishers/
- https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

Unfortunately the test pipeline still fails (which will be addressed later in #55) and the workflow can only be tested using the TestPyPI and a slightly modified workflow, e.g.:

```yaml
jobs:
  publish:
    name: Upload release to TestPyPI
    runs-on: ubuntu-latest
    environment:
      name: testing
      url: https://test.pypi.org/p/pganonymize/
    permissions:
      id-token: write  # IMPORTANT: mandatory for trusted publishing
    steps:
      - uses: actions/checkout@v2
      - name: Set up Python
        uses: actions/setup-python@v4
        with:
          python-version: '3.11'
      - name: Install dependencies
        run: |
          python -m pip install --upgrade pip
          pip install setuptools wheel
      - name: Build and publish
        run: python setup.py sdist bdist_wheel
      - name: Publish package distributions to PyPI
        uses: pypa/gh-action-pypi-publish@release/v1
        with:
          repository-url: https://test.pypi.org/legacy/
```

I tested the upload in #55  and the upload was successful: https://github.com/rheinwerk-verlag/pganonymize/actions/runs/8284252773
