### PR TITLE
Support pg dump password

### DIFF
--- a/pganonymize/utils.py
+++ b/pganonymize/utils.py
@@ -275,8 +275,8 @@ def create_database_dump(filename, db_args):
     if db_args.get('password'):
         env_vars += 'PGPASSWORD={password}'.format(password=db_args['password'])
     arguments = '-d {dbname} -U {user} -h {host} -p {port}'.format(**db_args)
-    cmd = '{env_vars} pg_dump -Fc -Z 9 {args} -f {filename}'.format(
-        env_vars=env_vars,
+    cmd = '{env_vars}pg_dump -Fc -Z 9 {args} -f {filename}'.format(
+        env_vars='{} '.format(env_vars) if env_vars else '',
         args=arguments,
         filename=filename
     )

--- a/pganonymize/utils.py
+++ b/pganonymize/utils.py
@@ -271,8 +271,12 @@ def create_database_dump(filename, db_args):
     :param str filename: Path to the dumpfile that should be created
     :param dict db_args: A dictionary with database related information
     """
+    env_vars = ''
+    if db_args.get('password'):
+        env_vars += 'PGPASSWORD={password}'.format(password=db_args['password'])
     arguments = '-d {dbname} -U {user} -h {host} -p {port}'.format(**db_args)
-    cmd = 'pg_dump -Fc -Z 9 {args} -f {filename}'.format(
+    cmd = '{env_vars} pg_dump -Fc -Z 9 {args} -f {filename}'.format(
+        env_vars=env_vars,
         args=arguments,
         filename=filename
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,7 +56,7 @@ class TestCli(object):
              call('UPDATE "auth_user" t SET "first_name" = s."first_name", "last_name" = s."last_name", "email" = s."email" FROM "tmp_auth_user" s WHERE t."id" = s."id"')  # noqa
          ],
          1,
-         [call('pg_dump -Fc -Z 9 -d db -U root -h localhost -p 5432 -f ./dump.sql', shell=True)]
+         [call('PGPASSWORD=my-cool-password pg_dump -Fc -Z 9 -d db -U root -h localhost -p 5432 -f ./dump.sql', shell=True)]
          ],
 
         ['--list-providers',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -239,3 +239,9 @@ class TestCreateDatabaseDump(object):
         create_database_dump('/tmp/dump.gz', {'dbname': 'database', 'user': 'foo', 'host': 'localhost', 'port': 5432})
         mock_call.assert_called_once_with('pg_dump -Fc -Z 9 -d database -U foo -h localhost -p 5432 -f /tmp/dump.gz',
                                           shell=True)
+
+    @patch('pganonymize.utils.subprocess.call')
+    def test_with_password(self, mock_call):
+        create_database_dump('/tmp/dump.gz', {'dbname': 'database', 'user': 'foo', 'host': 'localhost', 'port': 5432, 'password': 'pass'})
+        mock_call.assert_called_once_with('PGPASSWORD=pass pg_dump -Fc -Z 9 -d database -U foo -h localhost -p 5432 -f /tmp/dump.gz',
+                                          shell=True)


### PR DESCRIPTION
First of all, it's a very nice tool, good job :star_struck: 

This PR allow to use password provided in the cli option for the `pg_dump` command
Otherwise using `--dump-file` option will ask for a password even if the password is given in the command