### PR TITLE
Allow to configure parallel option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,7 @@ Usage
     --dump-file DUMP_FILE
                             Create a database dump file with the given name
     --init-sql INIT_SQL   SQL to run before starting anonymization
+    --parallel            Data anonymization is done in parallel
 
 Despite the database connection values, you will have to define a YAML schema file, that includes
 all anonymization rules for that database. Take a look at the `schema documentation`_ or the

--- a/pganonymize/cli.py
+++ b/pganonymize/cli.py
@@ -6,7 +6,7 @@ import argparse
 import logging
 import time
 
-from pganonymize.config import config
+from pganonymize.config import config, validate_args_with_config
 from pganonymize.constants import DATABASE_ARGS, DEFAULT_SCHEMA_FILE
 from pganonymize.providers import provider_registry
 from pganonymize.utils import anonymize_tables, create_database_dump, get_connection, truncate_tables
@@ -70,6 +70,8 @@ def main(args):
         return 0
 
     config.schema_file = args.schema
+
+    validate_args_with_config(args, config)
 
     pg_args = get_pg_args(args)
     connection = get_connection(pg_args)

--- a/pganonymize/cli.py
+++ b/pganonymize/cli.py
@@ -50,7 +50,10 @@ def get_arg_parser():
     parser.add_argument(
         '--parallel',
         action='store_true',
-        help='Parallelize anonymization of value. WARNING: `fake.unique.*` providers are not compatible with this option',
+        help=(
+            'Parallelize anonymization of value.'
+            'WARNING: `fake.unique.*` providers are not compatible with this option'
+        ),
         default=False,
     )
 

--- a/pganonymize/cli.py
+++ b/pganonymize/cli.py
@@ -47,6 +47,12 @@ def get_arg_parser():
                         default=False)
     parser.add_argument('--dump-file', help='Create a database dump file with the given name')
     parser.add_argument('--init-sql', help='SQL to run before starting anonymization', default=False)
+    parser.add_argument(
+        '--parallel',
+        action='store_true',
+        help='Parallelize anonymization of value. WARNING: `fake.unique.*` providers are not compatible with this option',
+        default=False,
+    )
 
     return parser
 
@@ -75,7 +81,12 @@ def main(args):
 
     start_time = time.time()
     truncate_tables(connection)
-    anonymize_tables(connection, verbose=args.verbose, dry_run=args.dry_run)
+    anonymize_tables(
+        connection,
+        verbose=args.verbose,
+        dry_run=args.dry_run,
+        parallel=args.parallel,
+    )
 
     if not args.dry_run:
         connection.commit()

--- a/pganonymize/config.py
+++ b/pganonymize/config.py
@@ -2,6 +2,7 @@ import os
 import re
 
 import yaml
+from pganonymize.exceptions import InvalidConfiguration
 
 
 class Config(object):
@@ -55,3 +56,14 @@ def load_schema(schema_file):
 
 
 config = Config()
+
+
+def validate_args_with_config(args, config):
+    definitions = config.schema.get('tables', [])
+    for definition in definitions:
+        table_definition = list(definition.values())[0]
+        columns = table_definition.get('fields', [])
+        for column in columns:
+            column_config = list(column.values())[0]
+            if args.parallel and column_config['provider']['name'].startswith('fake.unique'):
+                raise InvalidConfiguration('`--parallel` option and `fake.unique.*` providers are incompatible')

--- a/pganonymize/exceptions.py
+++ b/pganonymize/exceptions.py
@@ -20,3 +20,7 @@ class ProviderAlreadyRegistered(PgAnonymizeException):
 
 class BadDataFormat(PgAnonymizeException):
     """Raised if the anonymized data cannot be copied."""
+
+
+class InvalidConfiguration(PgAnonymizeException):
+    """Raised if configuration is invalid."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ class TestCli(object):
     @pytest.mark.parametrize('cli_args, expected, expected_executes, commit_calls, call_dump', [
         ['--host localhost --port 5432 --user root --password my-cool-password --dbname db --schema ./tests/schemes/valid_schema.yml -v --init-sql "set work_mem=\'1GB\'"',  # noqa
          Namespace(verbose=1, list_providers=False, schema='./tests/schemes/valid_schema.yml', dbname='db', user='root',
-                   password='my-cool-password', host='localhost', port='5432', dry_run=False, dump_file=None, init_sql="set work_mem='1GB'"),  # noqa
+                   password='my-cool-password', host='localhost', port='5432', dry_run=False, dump_file=None, init_sql="set work_mem='1GB'", parallel=False),  # noqa
          [call("set work_mem='1GB'"),
           call('TRUNCATE TABLE "django_session"'),
           call('SELECT COUNT(*) FROM "auth_user"'),
@@ -32,7 +32,7 @@ class TestCli(object):
          ],
         ['--dry-run --host localhost --port 5432 --user root --password my-cool-password --dbname db --schema ./tests/schemes/valid_schema.yml -v --init-sql "set work_mem=\'1GB\'"',  # noqa
          Namespace(verbose=1, list_providers=False, schema='./tests/schemes/valid_schema.yml', dbname='db', user='root',
-                   password='my-cool-password', host='localhost', port='5432', dry_run=True, dump_file=None, init_sql="set work_mem='1GB'"),  # noqa
+                   password='my-cool-password', host='localhost', port='5432', dry_run=True, dump_file=None, init_sql="set work_mem='1GB'", parallel=False),  # noqa
          [call("set work_mem='1GB'"),
           call('TRUNCATE TABLE "django_session"'),
              call('SELECT "id", "first_name", "last_name", "email" FROM "auth_user" LIMIT 100'),
@@ -44,7 +44,7 @@ class TestCli(object):
          ],
         ['--dump-file ./dump.sql --host localhost --port 5432 --user root --password my-cool-password --dbname db --schema ./tests/schemes/valid_schema.yml -v --init-sql "set work_mem=\'1GB\'"',  # noqa
          Namespace(verbose=1, list_providers=False, schema='./tests/schemes/valid_schema.yml', dbname='db', user='root',
-                   password='my-cool-password', host='localhost', port='5432', dry_run=False, dump_file='./dump.sql', init_sql="set work_mem='1GB'"),  # noqa
+                   password='my-cool-password', host='localhost', port='5432', dry_run=False, dump_file='./dump.sql', init_sql="set work_mem='1GB'", parallel=False),  # noqa
          [
              call("set work_mem='1GB'"),
              call('TRUNCATE TABLE "django_session"'),
@@ -59,9 +59,9 @@ class TestCli(object):
          [call('PGPASSWORD=my-cool-password pg_dump -Fc -Z 9 -d db -U root -h localhost -p 5432 -f ./dump.sql', shell=True)]
          ],
 
-        ['--list-providers',
+        ['--list-providers --parallel',
          Namespace(verbose=None, list_providers=True, schema='schema.yml', dbname=None, user=None,
-                   password='', host='localhost', port='5432', dry_run=False, dump_file=None, init_sql=False),
+                   password='', host='localhost', port='5432', dry_run=False, dump_file=None, init_sql=False, parallel=True),
          [], 0, []
          ]
     ])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,12 +56,12 @@ class TestCli(object):
              call('UPDATE "auth_user" t SET "first_name" = s."first_name", "last_name" = s."last_name", "email" = s."email" FROM "tmp_auth_user" s WHERE t."id" = s."id"')  # noqa
          ],
          1,
-         [call('PGPASSWORD=my-cool-password pg_dump -Fc -Z 9 -d db -U root -h localhost -p 5432 -f ./dump.sql', shell=True)]
+         [call('PGPASSWORD=my-cool-password pg_dump -Fc -Z 9 -d db -U root -h localhost -p 5432 -f ./dump.sql', shell=True)]  # noqa
          ],
 
         ['--list-providers --parallel',
          Namespace(verbose=None, list_providers=True, schema='schema.yml', dbname=None, user=None,
-                   password='', host='localhost', port='5432', dry_run=False, dump_file=None, init_sql=False, parallel=True),
+                   password='', host='localhost', port='5432', dry_run=False, dump_file=None, init_sql=False, parallel=True),  # noqa
          [], 0, []
          ]
     ])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -236,12 +236,22 @@ class TestCreateDatabaseDump(object):
 
     @patch('pganonymize.utils.subprocess.call')
     def test(self, mock_call):
-        create_database_dump('/tmp/dump.gz', {'dbname': 'database', 'user': 'foo', 'host': 'localhost', 'port': 5432})
-        mock_call.assert_called_once_with('pg_dump -Fc -Z 9 -d database -U foo -h localhost -p 5432 -f /tmp/dump.gz',
-                                          shell=True)
+        create_database_dump(
+            '/tmp/dump.gz',
+            {'dbname': 'database', 'user': 'foo', 'host': 'localhost', 'port': 5432},
+        )
+        mock_call.assert_called_once_with(
+            'pg_dump -Fc -Z 9 -d database -U foo -h localhost -p 5432 -f /tmp/dump.gz',
+            shell=True,
+        )
 
     @patch('pganonymize.utils.subprocess.call')
     def test_with_password(self, mock_call):
-        create_database_dump('/tmp/dump.gz', {'dbname': 'database', 'user': 'foo', 'host': 'localhost', 'port': 5432, 'password': 'pass'})
-        mock_call.assert_called_once_with('PGPASSWORD=pass pg_dump -Fc -Z 9 -d database -U foo -h localhost -p 5432 -f /tmp/dump.gz',
-                                          shell=True)
+        create_database_dump(
+            '/tmp/dump.gz',
+            {'dbname': 'database', 'user': 'foo', 'host': 'localhost', 'port': 5432, 'password': 'pass'},
+        )
+        mock_call.assert_called_once_with(
+            'PGPASSWORD=pass pg_dump -Fc -Z 9 -d database -U foo -h localhost -p 5432 -f /tmp/dump.gz',
+            shell=True,
+        )


### PR DESCRIPTION
Allow to disable parallel option to restore `fake.unique.*` provider
This PR change the default behavior by disabling parallel. It feels more natural to me, but feel free to disagree, I can change it

Fix https://github.com/rheinwerk-verlag/pganonymize/issues/31

todo/post-merge: Add breaking change in the changelog