### PR TITLE
Remove a temporary table after it is used

### DIFF
--- a/pganonymize/utils.py
+++ b/pganonymize/utils.py
@@ -122,6 +122,7 @@ def build_and_then_import_data(
             data = parmap.map(process_row, records, columns, excludes, pm_pbar=verbose, pm_parallel=parallel)
             import_data(connection, temp_table, [primary_key] + column_names, filter(None, data))
     apply_anonymized_data(connection, temp_table, table, primary_key, columns)
+    remove_temporary_table(connection, temp_table)
 
     cursor.close()
 
@@ -187,6 +188,19 @@ def create_temporary_table(connection, definitions, source_table, temp_table, pr
                                      source_table=Identifier(source_table), columns=sql_columns)
                    .as_string(connection)
                    )
+    cursor.close()
+
+
+def remove_temporary_table(connection, temp_table):
+    """
+    Remove the temporary table created during the anonymization process.
+    
+    :param connection: A database connection instance.
+    :param str temp_table: Name of the temporary table to be removed.
+    """
+    cursor = connection.cursor()
+    sql = SQL('DROP TABLE IF EXISTS {temp_table}').format(temp_table=Identifier(temp_table))
+    cursor.execute(sql.as_string(connection))
     cursor.close()
 
 

--- a/pganonymize/utils.py
+++ b/pganonymize/utils.py
@@ -194,7 +194,7 @@ def create_temporary_table(connection, definitions, source_table, temp_table, pr
 def remove_temporary_table(connection, temp_table):
     """
     Remove the temporary table created during the anonymization process.
-    
+
     :param connection: A database connection instance.
     :param str temp_table: Name of the temporary table to be removed.
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,8 @@ class TestCli(object):
           call(
              'CREATE TEMP TABLE "tmp_auth_user" AS SELECT "id", "first_name", "last_name", "email"\n                    FROM "auth_user" WITH NO DATA'),  # noqa
           call('CREATE INDEX ON "tmp_auth_user" ("id")'),
-          call('UPDATE "auth_user" t SET "first_name" = s."first_name", "last_name" = s."last_name", "email" = s."email" FROM "tmp_auth_user" s WHERE t."id" = s."id"')  # noqa
+          call('UPDATE "auth_user" t SET "first_name" = s."first_name", "last_name" = s."last_name", "email" = s."email" FROM "tmp_auth_user" s WHERE t."id" = s."id"'),  # noqa
+          call('DROP TABLE IF EXISTS "tmp_auth_user"')
           ],
          1,
          []
@@ -38,7 +39,8 @@ class TestCli(object):
              call('SELECT "id", "first_name", "last_name", "email" FROM "auth_user" LIMIT 100'),
              call('CREATE TEMP TABLE "tmp_auth_user" AS SELECT "id", "first_name", "last_name", "email"\n                    FROM "auth_user" WITH NO DATA'),  # noqa
              call('CREATE INDEX ON "tmp_auth_user" ("id")'),
-             call('UPDATE "auth_user" t SET "first_name" = s."first_name", "last_name" = s."last_name", "email" = s."email" FROM "tmp_auth_user" s WHERE t."id" = s."id"')  # noqa
+             call('UPDATE "auth_user" t SET "first_name" = s."first_name", "last_name" = s."last_name", "email" = s."email" FROM "tmp_auth_user" s WHERE t."id" = s."id"'),  # noqa
+             call('DROP TABLE IF EXISTS "tmp_auth_user"')
           ],
             0, []
          ],
@@ -53,7 +55,8 @@ class TestCli(object):
              call(
                  'CREATE TEMP TABLE "tmp_auth_user" AS SELECT "id", "first_name", "last_name", "email"\n                    FROM "auth_user" WITH NO DATA'),  # noqa
              call('CREATE INDEX ON "tmp_auth_user" ("id")'),
-             call('UPDATE "auth_user" t SET "first_name" = s."first_name", "last_name" = s."last_name", "email" = s."email" FROM "tmp_auth_user" s WHERE t."id" = s."id"')  # noqa
+             call('UPDATE "auth_user" t SET "first_name" = s."first_name", "last_name" = s."last_name", "email" = s."email" FROM "tmp_auth_user" s WHERE t."id" = s."id"'),  # noqa
+             call('DROP TABLE IF EXISTS "tmp_auth_user"')
          ],
          1,
          [call('PGPASSWORD=my-cool-password pg_dump --format plain --dbname db --username root --host localhost --port 5432 --file ./dump.sql', shell=True)]  # noqa

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -188,7 +188,9 @@ class TestBuildAndThenImport(object):
                                   call(
                                       'CREATE TEMP TABLE "tmp_src_tbl" AS SELECT "id", "col1", "COL2"\n                    FROM "src_tbl" WITH NO DATA'),  # noqa
                                   call('CREATE INDEX ON "tmp_src_tbl" ("id")'),
-                                  call('UPDATE "src_tbl" t SET "col1" = s."col1", "COL2" = s."COL2" FROM "tmp_src_tbl" s WHERE t."id" = s."id"')]  # noqa
+                                  call('UPDATE "src_tbl" t SET "col1" = s."col1", "COL2" = s."COL2" FROM "tmp_src_tbl" s WHERE t."id" = s."id"'),
+                                  call('DROP TABLE IF EXISTS "tmp_src_tbl"')
+                                  ]  # noqa
         assert mock_cursor.execute.call_args_list == expected_execute_calls
 
     @patch('pganonymize.utils.CopyManager')


### PR DESCRIPTION
When a single table needs multiple different anonymizations based on different search criteria, the task fails because the temporary table created to facilitate the process is not removed. The PR removes the temp table once it's no longer needed.