### PR TITLE
Explicitly close files to prevent resource leak

### DIFF
--- a/pganonymize/config.py
+++ b/pganonymize/config.py
@@ -52,7 +52,8 @@ def load_schema(schema_file):
         return value
 
     custom_loader.add_constructor(tag, constructor_env_variables)
-    return yaml.load(open(schema_file), Loader=custom_loader)
+    with open(schema_file) as f:
+        return yaml.load(f, Loader=custom_loader)
 
 
 config = Config()


### PR DESCRIPTION
This pull request fixes one file-handling issues in the `pganonymize/config.py`

The current implementation uses `open()` without explicitly closing the resulting files, which could potentially lead to resource leaks. Although Python’s garbage collector will eventually close a file once it is no longer referenced, it is generally better practice to close files explicitly or use a context manager.

This change replaces the direct `open()` call with a with statement to ensure proper file closure and follow Python best practices.

The issue was identified during an ongoing research project.